### PR TITLE
Fix "tar: -: Cannot stat" errors

### DIFF
--- a/lib/kitchen/transport/sshtar.rb
+++ b/lib/kitchen/transport/sshtar.rb
@@ -45,7 +45,7 @@ module Kitchen
               local_dir = File.dirname(local)
               local_file = File.basename(local)
               full_remote = remote
-              tar_command = "tar -C #{local_dir} -c#{@logger.debug? ? 'v' : ''} - #{local_file}"
+              tar_command = "tar -C #{local_dir} -c#{@logger.debug? ? 'v' : ''}f - #{local_file}"
               untar_command = "tar #{@logger.debug? ? '' : '--warning=none'} -C #{full_remote} -x#{@logger.debug? ? 'v' : ''}f - #{local_file}"
             end
             time = Benchmark.realtime do


### PR DESCRIPTION
Adding `f` option to tar_command to address stat errors.  Example:

```
       [SSH-TAR] Time taken to upload /var/folders/dn/cnk1zjcs6qnczhy3dgz9qvwdpnkp87/T/default-centos-7-sandbox-20180828-21457-l68yri/cookbook_artifacts to centos@10.225.123.129<{:user_known_hosts_file=>"/dev/null", :port=>22, :compression=>false, :compression_level=>0, :keepalive=>true, :keepalive_interval=>60, :timeout=>15, :keys_only=>true, :keys=>["/Users/cdenyar/cookbooks/example_cookbook/.kitchen/default-centos-7.pem"], :auth_methods=>["publickey"], :verify_host_key=>false, :logger=>#<Logger:0x00007f9121063d80 @level=4, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007f9121063ce0 @datetime_format=nil>, @formatter=nil, @logdev=#<Logger::LogDevice:0x00007f9121063c68 @shift_period_suffix=nil, @shift_size=nil, @shift_age=nil, @filename=nil, @dev=#<IO:<STDERR>>, @mon_owner=nil, @mon_count=0, @mon_mutex=#<Thread::Mutex:0x00007f9121063c18>>>, :password_prompt=>#<Net::SSH::Prompt:0x00007f9121063bf0>, :user=>"centos"}>:/tmp/kitchen/cookbook_artifacts: 3.92 sec
tar: -: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
```