### PR TITLE
Resolve Inspec compatibiliy support

### DIFF
--- a/lib/kitchen/transport/sshtar.rb
+++ b/lib/kitchen/transport/sshtar.rb
@@ -32,6 +32,16 @@ module Kitchen
         @connection = self.class::Connection.new(options, &block)
       end
 
+      def finalize_config!(instance)
+        super.tap do
+          if defined?(Kitchen::Verifier::Inspec) && instance.verifier.is_a?(Kitchen::Verifier::Inspec)
+            instance.verifier.send(:define_singleton_method, :runner_options_for_sshtar) do |config_data|
+              runner_options_for_ssh(config_data)
+            end
+          end
+        end
+      end
+
       class Connection < Ssh::Connection
         def upload(locals, remote)
           Array(locals).each do |local|


### PR DESCRIPTION
Per the comment under kitchen-inspec issue adding configuration details for inspec to use the sshtar transport.

https://github.com/inspec/kitchen-inspec/issues/160#issuecomment-397516889

Resolves the following error:

`>>>>>>     Failed to complete #verify action: [Verifier Inspec does not support the Sshtar Transport] on default-centos-7`